### PR TITLE
Filter jobs by name

### DIFF
--- a/app/models/job.server.ts
+++ b/app/models/job.server.ts
@@ -41,7 +41,7 @@ export async function getJobs(bartenderToken: string, limit = 100, offset = 0) {
       },
     },
   });
-  if (!response.ok || !data) {
+  if (!response.ok) {
     throw response;
   }
   return data;

--- a/app/routes/jobs._index.tsx
+++ b/app/routes/jobs._index.tsx
@@ -5,6 +5,7 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
   SortingState,
@@ -18,11 +19,13 @@ import {
   PencilIcon,
 } from "lucide-react";
 import { PropsWithChildren, useState } from "react";
+import { useTheme } from "remix-themes";
 
 import { getBartenderToken } from "~/bartender-client/token.server";
 import { JobModelDTO } from "~/bartender-client/types";
 import { DataTablePagination } from "~/components/DataTablePagination";
 import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
 import {
   Table,
   TableBody,
@@ -35,9 +38,25 @@ import { cn } from "~/lib/utils";
 import { getJobs } from "~/models/job.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  const token = await getBartenderToken(request);
-  const jobs = await getJobs(token);
-  return json({ jobs });
+  try {
+    const token = await getBartenderToken(request);
+    const jobs = await getJobs(token);
+    return json({
+      jobs: (jobs as JobModelDTO[]) ?? ([] as JobModelDTO[]),
+      error: null,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (resp: any) {
+    // authentication errors are handled by error boundary
+    if ([401, 403].includes(resp.status)) {
+      throw resp;
+    } else {
+      return json({
+        jobs: [] as JobModelDTO[],
+        error: `${resp.status} - ${resp.statusText}`,
+      });
+    }
+  }
 };
 
 const columnHelper = createColumnHelper<JobModelDTO>();
@@ -150,8 +169,11 @@ function DeleteAction({
 }
 
 export default function JobsPage() {
-  const { jobs } = useLoaderData<typeof loader>();
+  const { jobs, error } = useLoaderData<typeof loader>();
   const { submit, state: fetcherState } = useFetcher();
+  const [theme] = useTheme();
+  const colorScheme = { colorScheme: theme === "dark" ? "dark" : "light" };
+
   const columns = [
     columnHelper.accessor("id", {
       cell: ({ row }) => (
@@ -230,6 +252,7 @@ export default function JobsPage() {
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
     state: {
       sorting,
     },
@@ -242,6 +265,19 @@ export default function JobsPage() {
 
   return (
     <main>
+      <div className="flex items-center pb-4">
+        <Input
+          placeholder="Filter jobs by name..."
+          type="search"
+          value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
+          onChange={({ target }) => {
+            // console.log("onChange...", target.value)
+            table.getColumn("name")?.setFilterValue(target.value);
+          }}
+          style={colorScheme}
+          className="max-w-sm"
+        />
+      </div>
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
@@ -275,7 +311,13 @@ export default function JobsPage() {
           ) : (
             <TableRow>
               <TableCell colSpan={columns.length} className="h-24 text-center">
-                No jobs.
+                {error ? (
+                  <span className="text-error">
+                    Failed to load job list. {error}
+                  </span>
+                ) : (
+                  <span className="">No jobs</span>
+                )}
               </TableCell>
             </TableRow>
           )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haddock3-webapp",
-  "version": "0.2.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haddock3-webapp",
-      "version": "0.2.0",
+      "version": "0.3.2",
       "dependencies": {
         "@i-vresse/haddock3-analysis-components": "^0.4.1",
         "@i-vresse/wb-core": "^3.0.0",


### PR DESCRIPTION
# Add job search by name

Closes #100 

Changes: 
- The user can filter jobs on name. It uses filtering implementation of table component. It filters on (part of) job name as suggested in #100 
- Show empty manage list on error and received error message from back-end

## How to test?
- start the solution including the back-end
- upload few workflow jobs to create job list
- use search to filter job list. It filters on job name on each key stroke (debounce is not implemented)

## List
![image](https://github.com/i-VRESSE/haddock3-webapp/assets/9204081/f6bd7ea2-29ab-4059-bf0e-485c17160d76)

## Filtered list
![image](https://github.com/i-VRESSE/haddock3-webapp/assets/9204081/b3dbc834-33d3-447b-adc0-a7b6bb81d01d)


