### PR TITLE
Fix parameter name in seletopclusts

### DIFF
--- a/app/catalogs/haddock3.easy.json
+++ b/app/catalogs/haddock3.easy.json
@@ -2186,7 +2186,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "top_cluster": {
+          "top_clusters": {
             "default": 1000,
             "title": "Number of clusters to consider",
             "description": "Number of clusters to consider (ranked by score)",

--- a/app/catalogs/haddock3.expert.json
+++ b/app/catalogs/haddock3.expert.json
@@ -8798,7 +8798,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "top_cluster": {
+          "top_clusters": {
             "default": 1000,
             "title": "Number of clusters to consider",
             "description": "Number of clusters to consider (ranked by score)",

--- a/app/catalogs/haddock3.guru.json
+++ b/app/catalogs/haddock3.guru.json
@@ -9220,7 +9220,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "top_cluster": {
+          "top_clusters": {
             "default": 1000,
             "title": "Number of clusters to consider",
             "description": "Number of clusters to consider (ranked by score)",

--- a/app/routes/scenarios.antibody-antigen.tsx
+++ b/app/routes/scenarios.antibody-antigen.tsx
@@ -116,10 +116,11 @@ ${unambig_line}
 
 [clustfcc]
 min_population = 10
+plot_matrix = true
 
 [seletopclusts]
-## select all the clusters
-top_cluster = 500
+## select top 500 clusters
+top_clusters = 500
 ## select the best 10 models of each cluster
 top_models = 10
 
@@ -146,7 +147,9 @@ ${unambig_line}
 [clustfcc]
 
 [seletopclusts]
-top_cluster = 500
+top_clusters = 500
+## select the best 10 models of each cluster
+top_models = 4
 
 [caprieval]
 ${ref_line}

--- a/app/routes/scenarios.protein-glycan.tsx
+++ b/app/routes/scenarios.protein-glycan.tsx
@@ -115,9 +115,11 @@ ${ref_line}
 [clustrmsd]
 criterion = 'maxclust'
 n_clusters = 50 # the number of clusters to be formed
+plot_matrix = true
 
 [seletopclusts]
-top_models = 5
+top_clusters = 50
+top_models = 20
 
 [caprieval]
 ${ref_line}
@@ -135,8 +137,6 @@ ${ref_line}
 [clustrmsd]
 criterion = 'distance'
 linkage = 'average'
-# full example, 4 models should be present in a cluster
-min_population = 4
 clust_cutoff = 2.5 
 
 [seletopclusts]

--- a/app/routes/scenarios.protein-ligand.tsx
+++ b/app/routes/scenarios.protein-ligand.tsx
@@ -142,8 +142,9 @@ ${ref_line}
 [ilrmsdmatrix]
 
 [clustrmsd]
-criterion = 'maxclust'
-n_clusters = 4 # the number of clusters to be formed
+criterion = 'distance'
+clust_cutoff = 2.5
+plot_matrix = true
 
 [seletopclusts]
 top_models = 4

--- a/app/routes/scenarios.scoring.tsx
+++ b/app/routes/scenarios.scoring.tsx
@@ -110,6 +110,9 @@ function generateWorkflow(
     undefined,
     2,
   );
+  const ref_line = data.reference_fname
+    ? `reference_fname = "${data.reference_fname.name}"`
+    : "";
 
   // easy is not allowed to set tolerance
   const tolerance_line =
@@ -289,7 +292,7 @@ export default function ScoringScenario() {
               </div>
             </details>
             <ReferenceStructureInput>
-              In example named data/e2a-hpr_1GGR.pdb
+              
             </ReferenceStructureInput>
             <FormErrors errors={errors ?? actionData?.errors} />
             <ActionButtons />

--- a/app/routes/scenarios.scoring.tsx
+++ b/app/routes/scenarios.scoring.tsx
@@ -29,6 +29,7 @@ import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { ActionButtons, handleActionButton } from "~/scenarios/actions";
 import { FormErrors } from "~/scenarios/FormErrors";
+import { ReferenceStructureInput } from "~/scenarios/ReferenceStructureInput";
 import { PDBFilesInput } from "~/scenarios/PDBFilesInput.client";
 import {
   moleculeFieldDescription,
@@ -49,7 +50,7 @@ export const action = uploadaction;
 const fieldDescriptions = {
   molecules: moleculeFieldDescription,
   ...getModuleDescriptions(`clustfcc`, ["clust_cutoff", "min_population"]),
-  ...getModuleDescriptions(`seletopclusts`, ["top_models", "top_cluster"]),
+  ...getModuleDescriptions(`seletopclusts`, ["top_models", "top_clusters"]),
 } as {
   // TODO do fancy typescipt so cast is not needed
   molecules: Description;
@@ -136,6 +137,7 @@ ${tolerance_line}
 ${tolerance_line}
 
 [caprieval]
+${ref_line}
 
 [clustfcc]
 min_population = ${data.min_population}
@@ -143,9 +145,10 @@ clust_cutoff = ${data.clust_cutoff}
 
 [seletopclusts]
 top_models = ${data.top_models}
-top_cluster = ${data.top_cluster}
+top_clusters = ${data.top_cluster}
 
 [caprieval]
+${ref_line}
 # ===================================================================================
   `;
 }
@@ -285,6 +288,9 @@ export default function ScoringScenario() {
                 />
               </div>
             </details>
+            <ReferenceStructureInput>
+              In example named data/e2a-hpr_1GGR.pdb
+            </ReferenceStructureInput>
             <FormErrors errors={errors ?? actionData?.errors} />
             <ActionButtons />
           </form>

--- a/app/scenarios/ResiduesSelect.tsx
+++ b/app/scenarios/ResiduesSelect.tsx
@@ -164,7 +164,7 @@ export function PickIn3D({
       <ToggleGroup type="single" defaultValue={value} onValueChange={onChange}>
         <ToggleGroupItem
           value="act"
-          className="data-[state=on]:bg-green-100"
+          className="data-[state=on]:bg-red-100"
           aria-label="Picking in 3D viewer will select active"
           title="Picking in 3D viewer will select active"
         >
@@ -172,9 +172,9 @@ export function PickIn3D({
         </ToggleGroupItem>
         <ToggleGroupItem
           value="pass"
-          className="data-[state=on]:bg-yellow-100"
-          aria-label="Picking in 3D will viwer select passive"
-          title="Picking in 3D will viwer select passive"
+          className="data-[state=on]:bg-green-100"
+          aria-label="Picking in 3D viewer will select passive"
+          title="Picking in 3D viewer will select passive"
         >
           P
         </ToggleGroupItem>


### PR DESCRIPTION
This PR solves the parameter name `top_cluster` to `top_clusters`  used in seletopclusts in scenarios.

